### PR TITLE
Fix contributor link

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,4 +1,4 @@
-[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](https://github.com/scipp/.github/blob/main/profile/CODE_OF_CONDUCT.md)
 
 # Welcome to the Scipp Organization
 


### PR DESCRIPTION
The previous link only works when clicked in the `.github/profile` folder not in the organisation landing page.